### PR TITLE
docs: adiciona instruções de Git Subtree

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -2740,6 +2740,31 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Git Subtree\n",
+    "\n",
+    "Se você preferir que os arquivos do repositório `AGENTS` fiquem na raiz do projeto principal, utilize o `git subtree`.\n",
+    "\n",
+    "1. Adicione o repositório secundário:\n",
+    "\n",
+    "    ```bash\n",
+    "    git subtree add --prefix=. git@github.com:usuario/AGENTS.git main --squash\n",
+    "    ```\n",
+    "\n",
+    "    * `--prefix=.` copia o conteúdo para a raiz do projeto.\n",
+    "    * `--squash` mantém o histórico compacto.\n",
+    "\n",
+    "2. Para atualizar posteriormente:\n",
+    "\n",
+    "    ```bash\n",
+    "    git subtree pull --prefix=. git@github.com:usuario/AGENTS.git main --squash\n",
+    "    ```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "60ac5332",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Resumo
- adiciona guia para integrar AGENTS via git subtree

## Testes
- `python convert_ipynb_to_md_and_py.py README.ipynb` *(falhou: ModuleNotFoundError: No module named 'nbconvert')*
- `pip install nbconvert` *(falhou: Could not find a version that satisfies the requirement nbconvert)*
- `sudo apt-get update` *(falhou: 403 Forbidden ao acessar repositórios)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d4c37068483229b908dc0a71d190e